### PR TITLE
Fix openId Response urls when using minikube and ingress

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorController.java
+++ b/src/main/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorController.java
@@ -71,9 +71,6 @@ public class IdamSimulatorController {
     @Value("${simulator.jwt.issuer}")
     private String jwtIssuer;
 
-    @Value("${server.port}")
-    private int idamServerPort;
-
     @Value("${simulator.openid.base-url}")
     private String idamBaseUrl;
 
@@ -230,7 +227,7 @@ public class IdamSimulatorController {
     public ResponseEntity<OpenIdConfig> getOpenIdConfig() {
         LOG.info("Request openIdConfig");
         OpenIdConfig openIdConfig = openIdConfigService
-            .getOpenIdConfig(idamBaseUrl, idamServerPort, jwtIssuer);
+            .getOpenIdConfig(idamBaseUrl, jwtIssuer);
         return ResponseEntity.ok(openIdConfig);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/rse/idam/simulator/service/token/OpenIdConfigService.java
+++ b/src/main/java/uk/gov/hmcts/reform/rse/idam/simulator/service/token/OpenIdConfigService.java
@@ -16,10 +16,9 @@ public class OpenIdConfigService {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenIdConfigService.class);
 
-    public OpenIdConfig getOpenIdConfig(String baseUrl, int serverPort, String issuer) {
+    public OpenIdConfig getOpenIdConfig(String baseUrl, String issuer) {
         OpenIdConfig openIdConfig = new OpenIdConfig();
-        String basePath = baseUrl.concat(":" + serverPort);
-        openIdConfig.authorizationEndpoint(basePath + "/o/authorize")
+        openIdConfig.authorizationEndpoint(baseUrl + "/o/authorize")
             .requestParameterSupported(true)
             .claimsParameterSupported(true)
             .scopesSupported(Arrays.asList("openid", "profile", "roles"))
@@ -83,11 +82,11 @@ public class OpenIdConfigService {
             ))
             .rcsResponseEncryptionEncValuesSupported(Arrays.asList("A256GCM", "A128CBC-HS256", "A256CBC-HS512"))
             .issuer(issuer)
-            .tokenEndpoint(basePath + "/o/token")
-            .userinfoEndpoint(basePath + "/o/userinfo")
-            .jwksUri(basePath + "/o/jwks")
-            .issuer(basePath + "/o")
-            .endSessionEndpoint(basePath + "/o/endSession")
+            .tokenEndpoint(baseUrl + "/o/token")
+            .userinfoEndpoint(baseUrl + "/o/userinfo")
+            .jwksUri(baseUrl + "/o/jwks")
+            .issuer(baseUrl + "/o")
+            .endSessionEndpoint(baseUrl + "/o/endSession")
             .checkSessionIframe(null)
             .introspectionEndpoint(null)
             .registrationEndpoint(null);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,7 +16,7 @@ simulator:
     issuer: http://localhost:5556
     expiration: 14400000 # milliseconds 4 hours
   openid:
-    base-url: http://localhost
+    base-url: http://localhost:5556
 
 logging:
   level:


### PR DESCRIPTION
### Change description ###
Fixes `open-id /o/.well-known/openid-configuration` endpoint urls when using a local kubernetes environment with ingress. Fixed by removing server port logic from issuer url instea if the url needs to use a port it should be passed as `simulator.openid.base-url` environment variable

