### PR TITLE
HMAN-311 - Make unused parameters optional

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Login to Azure Container Repository
         uses: docker/login-action@v1
         with:
-          registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: ${{ env.AZURE_CONTAINER_REGISTRY_URL }}
+          username: ${{ secrets.AZURE_CLIENT_ID }}
+          password: ${{ secrets.AZURE_CLIENT_SECRET }}
       - run: |
           docker buildx create --name mybuilder --use
           docker buildx build --push --platform linux/amd64,linux/arm64 -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/hmcts/rse/rse-idam-simulator:latest .

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,8 +17,8 @@ jobs:
         java-version: 11
     - name: Build
       run: ./gradlew build -i
-    - name: Push to ACR
-      uses: azure/docker-login@v1
+    - name: Login to Azure Container Repository
+      uses: azure/login-action@v1
       with:
         login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
         username: ${{ secrets.REGISTRY_USERNAME }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,23 +10,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - name: Build
-      run: ./gradlew build -i
-    - name: Login to Azure Container Repository
-      uses: azure/login-action@v1
-      with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - run: |
-        docker buildx create --name mybuilder --use
-        docker buildx build --push --platform linux/amd64,linux/arm64 -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/hmcts/rse/rse-idam-simulator:latest .
-      if: github.ref == 'refs/heads/master'
+      - uses: actions/checkout@v1
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build
+        run: ./gradlew build -i
+      - name: Login to Azure Container Repository
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - run: |
+          docker buildx create --name mybuilder --use
+          docker buildx build --push --platform linux/amd64,linux/arm64 -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/hmcts/rse/rse-idam-simulator:latest .
+        if: github.ref == 'refs/heads/master'
 
 
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ docker run -d -P --name rse-idam-simulator -p 5556:5556 hmctspublic.azurecr.io/h
 ## Running/Debugging the application with IntelliJ Idea
 Right click on Application.java and choose Run 'Application.main()' or Debug 'Application.main()'
 
-Open this url http://localhost:5556/health to check it has started correctly
+Open this url `http://localhost:5556/health` to check it has started correctly
 
 ## How to use the simulator with Post Man
 Check IdamSimulatorController to see how works the endpoints. These endpoints are all the endpoints required to have the idam java client working correctly,
@@ -36,8 +36,11 @@ Content-type: application/json
 
 "email": "myemail-test@hmcts.net",
 "forename": "John",
-"surename": "Smith",
-"roles": ["role1", "role2"],
+"surname": "Smith",
+"roles": [
+    {"code": "role1"},
+    {"code": "role2"}
+],
 "password": "onePassword"
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorController.java
+++ b/src/main/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorController.java
@@ -82,8 +82,10 @@ public class IdamSimulatorController {
     @PostMapping(value = "/oauth2/authorize", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public AuthenticateUserResponse authoriseUser(@RequestHeader(AUTHORIZATION) String authorization,
                                                   @RequestParam(CLIENT_ID) final String clientId,
-                                                  @RequestParam(REDIRECT_URI) final String redirectUri,
-                                                  @RequestParam("response_type") final String responseType
+                                                  @RequestParam(value = REDIRECT_URI, required = false)
+                                                      final String redirectUri,
+                                                  @RequestParam(value = "response_type", required = false)
+                                                      final String responseType
     ) {
         LOG.warn("oauth2/authorize endpoint is deprecated!");
         LOG.info("Request oauth2 authorise for clientId {}", clientId);
@@ -102,7 +104,7 @@ public class IdamSimulatorController {
     @Deprecated
     @PostMapping(value = "/oauth2/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public TokenResponse oauth2Token(@RequestParam(value = CLIENT_ID, required = false) String clientId,
-                                     @RequestParam(REDIRECT_URI) final String redirectUri,
+                                     @RequestParam(name = REDIRECT_URI, required = false) final String redirectUri,
                                      @RequestParam(value = "client_secret", required = false) String clientSecret,
                                      @RequestParam("grant_type") final String grantType,
                                      @RequestParam("code") final String code,
@@ -160,9 +162,9 @@ public class IdamSimulatorController {
 
     @GetMapping(value = "/pin", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public ResponseEntity<Object> getPin(@RequestHeader("pin") final String pin,
-                                         @RequestParam(CLIENT_ID) final String clientId,
+                                         @RequestParam(value = CLIENT_ID, required = false) final String clientId,
                                          @RequestParam(REDIRECT_URI) final String redirectUri,
-                                         @RequestParam("state") final String state) {
+                                         @RequestParam(value = "state", required = false) final String state) {
         LOG.info("Get Request Pin for pin {} to generate new code in Location Header", pin);
         HttpHeaders httpHeaders = new HttpHeaders();
         String generatedPinCode = simulatorService.generateOauth2CodeFromPin(pin);
@@ -204,11 +206,13 @@ public class IdamSimulatorController {
 
     @PostMapping(value = "/o/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public TokenResponse getOpenIdToken(@RequestParam(CLIENT_ID) final String clientId,
-                                        @RequestParam(REDIRECT_URI) final String redirectUri,
-                                        @RequestParam("client_secret") final String clientSecret,
+                                        @RequestParam(name = REDIRECT_URI, required = false) final String redirectUri,
+                                        @RequestParam(value = "client_secret", required = false)
+                                            final String clientSecret,
                                         @RequestParam("grant_type") final String grantType,
                                         @RequestParam("username") final String username,
-                                        @RequestParam("password") final String password,
+                                        @RequestParam(value = "password", required = false)
+                                            final String password,
                                         @RequestParam("scope") final String scope,
                                         @RequestParam(name = "code", required = false) final String code) {
         LOG.info(
@@ -252,7 +256,7 @@ public class IdamSimulatorController {
     }
 
     @PostMapping(value = "/o/authorize", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    public ResponseEntity<Object> postoAutorize(
+    public ResponseEntity<Object> postToAuthorize(
         @RequestParam(value = "client_id", required = false) String clientId,
         @RequestParam(value = "redirect_uri", required = false) String redirectUri,
         @RequestParam(value = "state", required = false) String state,


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [HMAN-311](https://tools.hmcts.net/jira/browse/HMAN-311) _"POC ticket to add CCD chart to HMC, add a message to hearing service and make a call to Future Hearing"_

### Change description ###

This idam simulator is being used with `hmc-cft-hearing-service` as part of the [rse-cft-lib](https://github.com/hmcts/rse-cft-lib) gradle `bootWithCCD` plugin

Currently BEFTA tests fail when making rest calls to the the idam simulator as they are not passing a `redirect_uri`.  This PR makes that, and other unused parameters, optional.  They have not been removed as this would be a breaking change to any existing clients using these simulator endpoints

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
