### PR TITLE
RIA-6554 ia-idam-express-middleware missing endpoint for openId true

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorControllersHappyPathTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorControllersHappyPathTest.java
@@ -194,6 +194,33 @@ public class IdamSimulatorControllersHappyPathTest {
             .updateTokenInUser(A_USER_NAME, TOKEN);
     }
 
+    @DisplayName("Should return an open id token from code")
+    @Test
+    public void returnOpenIdTokenFromCode() throws Exception {
+        when(simulatorService.generateAuthTokenFromCode(anyString(), anyString(), anyString())).thenReturn(TOKEN);
+
+        mockMvc.perform(post("/o/token")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                            .param(CLIENT_ID, CLIENT_ID_HMCTS)
+                            .param("client_secret", "oneClientSecret")
+                            .param("grant_type", "authorization_code")
+                            .param(REDIRECT_URI, "aRedirectUrl")
+                            .param("code", "someCode")
+                            .param("scope", "openid profile roles"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.access_token").isString())
+            .andExpect(jsonPath("$.expires_in").isString())
+            .andExpect(jsonPath("$.id_token").isString())
+            .andExpect(jsonPath("$.refresh_token").isString())
+            .andExpect(jsonPath("$.scope").value("openid profile roles"))
+            .andExpect(jsonPath("$.token_type").value("Bearer"))
+            .andExpect(jsonPath("$.access_token").isString())
+            .andReturn();
+
+        verify(simulatorService, times(3))
+            .generateAuthTokenFromCode(anyString(), anyString(), anyString());
+    }
+
     @DisplayName("Should return expected user info")
     @Test
     public void returnUserInfo() throws Exception {

--- a/src/main/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorController.java
+++ b/src/main/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorController.java
@@ -149,7 +149,7 @@ public class IdamSimulatorController {
         if (!(grantType.equalsIgnoreCase(GRANT_TYPE_AUTHORIZATION_CODE))) {
             throw new ResponseStatusException(
                 HttpStatus.BAD_REQUEST,
-                "Idam Simulator: Grand type not valid" + grantType + ", must be " + GRANT_TYPE_AUTHORIZATION_CODE
+                "Idam Simulator: Grand type not valid" + grantType + " , must be " + GRANT_TYPE_AUTHORIZATION_CODE
             );
         }
     }
@@ -204,7 +204,7 @@ public class IdamSimulatorController {
         return createUserDetailsList();
     }
 
-    @PostMapping(value = "/o/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    @PostMapping(value = "/o/token", params = "username", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public TokenResponse getOpenIdToken(@RequestParam(CLIENT_ID) final String clientId,
                                         @RequestParam(name = REDIRECT_URI, required = false) final String redirectUri,
                                         @RequestParam(value = "client_secret", required = false)
@@ -213,20 +213,49 @@ public class IdamSimulatorController {
                                         @RequestParam("username") final String username,
                                         @RequestParam(value = "password", required = false)
                                             final String password,
-                                        @RequestParam("scope") final String scope,
-                                        @RequestParam(name = "code", required = false) final String code) {
+                                        @RequestParam("scope") final String scope) {
         LOG.info(
-            "Request OpenId Token for clientId {} Username {} scope {} and code {}",
+            "Request OpenId Token for clientId {} Username {} scope {}",
             clientId,
             username,
-            scope,
-            code
+            scope
         );
         String token = simulatorService.generateACachedToken(username, clientId, grantType);
         String refreshToken = simulatorService.generateAToken(username, clientId, grantType);
         String idToken = simulatorService.generateAToken(username, clientId, grantType);
         LOG.info("Access Open Id Token returned {}", token);
         simulatorService.updateTokenInUser(username, token);
+        return new TokenResponse(token, String.valueOf(expiration), idToken, refreshToken,
+                                 "openid profile roles", "Bearer"
+        );
+    }
+
+    @PostMapping(value = "/o/token", params = "code", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    public TokenResponse getOpenIdTokenFromCode(@RequestParam(CLIENT_ID) final String clientId,
+                                                @RequestParam(name = REDIRECT_URI, required = false)
+                                                final String redirectUri,
+                                                @RequestParam(value = "client_secret", required = false)
+                                                    final String clientSecret,
+                                                @RequestParam("grant_type") final String grantType,
+
+                                                final String password,
+                                                @RequestParam(value = "scope", required = false) final String scope,
+                                                @RequestParam(name = "code") final String code) {
+        LOG.info(
+            "Request OpenId Token for clientId {} scope {} and code {}",
+            clientId,
+            scope,
+            code
+        );
+
+        checkGrantType(grantType);
+        checkCode(code);
+
+        String token = simulatorService.generateAuthTokenFromCode(code, clientId, grantType);
+        String refreshToken = simulatorService.generateAuthTokenFromCode(code, clientId, grantType);
+        String idToken = simulatorService.generateAuthTokenFromCode(code, clientId, grantType);
+        LOG.info("Access Open Id Token generated from code {}", token);
+
         return new TokenResponse(token, String.valueOf(expiration), idToken, refreshToken,
                                  "openid profile roles", "Bearer"
         );


### PR DESCRIPTION
### Change description ###
The IAC ia-aip-frontend uses ia-idam-express-middleware with openId: true to authenticate. 
But the idam simulator doesn't support authentication against /o/token with a code meaning this configuration fails to authenticate.

Added the endpoint and a test.


