### PR TITLE
RIA-6554 ia-idam-express-middleware missing endpoint for openId true

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorControllersHappyPathTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorControllersHappyPathTest.java
@@ -194,6 +194,33 @@ public class IdamSimulatorControllersHappyPathTest {
             .updateTokenInUser(A_USER_NAME, TOKEN);
     }
 
+    @DisplayName("Should return an open id token from code")
+    @Test
+    public void returnOpenIdTokenFromCode() throws Exception {
+        when(simulatorService.generateAuthTokenFromCode(anyString(), anyString(), anyString())).thenReturn(TOKEN);
+
+        mockMvc.perform(post("/o/token")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                            .param(CLIENT_ID, CLIENT_ID_HMCTS)
+                            .param("client_secret", "oneClientSecret")
+                            .param("grant_type", "authorization_code")
+                            .param(REDIRECT_URI, "aRedirectUrl")
+                            .param("code", "someCode")
+                            .param("scope", "openid profile roles"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.access_token").isString())
+            .andExpect(jsonPath("$.expires_in").isString())
+            .andExpect(jsonPath("$.id_token").isString())
+            .andExpect(jsonPath("$.refresh_token").isString())
+            .andExpect(jsonPath("$.scope").value("openid profile roles"))
+            .andExpect(jsonPath("$.token_type").value("Bearer"))
+            .andExpect(jsonPath("$.access_token").isString())
+            .andReturn();
+
+        verify(simulatorService, times(3))
+            .generateAuthTokenFromCode(anyString(), anyString(), anyString());
+    }
+
     @DisplayName("Should return expected user info")
     @Test
     public void returnUserInfo() throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorControllersHappyPathTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorControllersHappyPathTest.java
@@ -194,33 +194,6 @@ public class IdamSimulatorControllersHappyPathTest {
             .updateTokenInUser(A_USER_NAME, TOKEN);
     }
 
-    @DisplayName("Should return an open id token from code")
-    @Test
-    public void returnOpenIdTokenFromCode() throws Exception {
-        when(simulatorService.generateAuthTokenFromCode(anyString(), anyString(), anyString())).thenReturn(TOKEN);
-
-        mockMvc.perform(post("/o/token")
-                            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-                            .param(CLIENT_ID, CLIENT_ID_HMCTS)
-                            .param("client_secret", "oneClientSecret")
-                            .param("grant_type", "authorization_code")
-                            .param(REDIRECT_URI, "aRedirectUrl")
-                            .param("code", "someCode")
-                            .param("scope", "openid profile roles"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.access_token").isString())
-            .andExpect(jsonPath("$.expires_in").isString())
-            .andExpect(jsonPath("$.id_token").isString())
-            .andExpect(jsonPath("$.refresh_token").isString())
-            .andExpect(jsonPath("$.scope").value("openid profile roles"))
-            .andExpect(jsonPath("$.token_type").value("Bearer"))
-            .andExpect(jsonPath("$.access_token").isString())
-            .andReturn();
-
-        verify(simulatorService, times(3))
-            .generateAuthTokenFromCode(anyString(), anyString(), anyString());
-    }
-
     @DisplayName("Should return expected user info")
     @Test
     public void returnUserInfo() throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorControllersSpringBootTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorControllersSpringBootTest.java
@@ -1,0 +1,120 @@
+package uk.gov.hmcts.reform.rse.idam.simulator.controllers;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.reform.idam.client.IdamApi;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.rse.idam.simulator.service.SimulatorDataFactory;
+import uk.gov.hmcts.reform.rse.idam.simulator.service.SimulatorService;
+import uk.gov.hmcts.reform.rse.idam.simulator.service.memory.LiveMemoryService;
+import uk.gov.hmcts.reform.rse.idam.simulator.service.memory.SimObject;
+import uk.gov.hmcts.reform.rse.idam.simulator.service.token.JsonWebKeyService;
+import uk.gov.hmcts.reform.rse.idam.simulator.service.token.JwTokenGeneratorService;
+import uk.gov.hmcts.reform.rse.idam.simulator.service.token.OpenIdConfigService;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.idam.client.IdamClient.GRANT_TYPE;
+
+@SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.JUnitAssertionsShouldIncludeMessage"})
+@EnableFeignClients(basePackages = {"uk.gov.hmcts.reform.idam.client"})
+@SpringBootTest(classes = {IdamClient.class, IdamApi.class, IdamSimulatorController.class,
+    LiveMemoryService.class, SimulatorService.class, JsonWebKeyService.class,
+    JwTokenGeneratorService.class, OpenIdConfigService.class},
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@PropertySource("classpath:application.yaml")
+@DirtiesContext
+@EnableAutoConfiguration
+@AutoConfigureMockMvc
+@RunWith(SpringRunner.class)
+public class IdamSimulatorControllersSpringBootTest {
+    public static final String CLIENT_ID = "client_id";
+    public static final String REDIRECT_URI = "redirect_uri";
+    public static final String CLIENT_ID_HMCTS = "hmcts";
+    private static final String CLIENT_SECRET = "client_secret";
+    private static final String GRANT_TYPE_NAME = "grant_type";
+    private static final String IDAM_SCOPE = "scope";
+    private static final String AUTH_TYPE_CODE = "code";
+    private static final String VALID_CODE = "itsAnOlderCodeSirButItChecksOut";
+
+    @SpyBean
+    SimulatorService simulatorService;
+
+    @SpyBean
+    LiveMemoryService liveMemoryService;
+
+    @Autowired
+    private transient MockMvc mockMvc;
+
+    @Before
+    public void setup() {
+        SimObject simObject = SimulatorDataFactory.createSimObject();
+        simObject.setMostRecentCode(VALID_CODE);
+        liveMemoryService.putSimObject(UUID.nameUUIDFromBytes(simObject.getEmail().getBytes()).toString(), simObject);
+    }
+
+    @DisplayName("Should return an open id token from code")
+    @Test
+    public void returnOpenIdTokenFromCode() throws Exception {
+
+        mockMvc.perform(post("/o/token")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                            .param(CLIENT_ID, CLIENT_ID_HMCTS)
+                            .param(CLIENT_SECRET, "oneClientSecret")
+                            .param(GRANT_TYPE_NAME, GRANT_TYPE)
+                            .param(REDIRECT_URI, "aRedirectUrl")
+                            .param(AUTH_TYPE_CODE, "itsAnOlderCodeSirButItChecksOut")
+                            .param(IDAM_SCOPE, "openid profile roles"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.access_token").isString())
+            .andExpect(jsonPath("$.expires_in").isString())
+            .andExpect(jsonPath("$.id_token").isString())
+            .andExpect(jsonPath("$.refresh_token").isString())
+            .andExpect(jsonPath("$.scope").value("openid profile roles"))
+            .andExpect(jsonPath("$.token_type").value("Bearer"))
+            .andExpect(jsonPath("$.access_token").isString())
+            .andReturn();
+
+        verify(liveMemoryService, times(3)).getByCode(VALID_CODE);
+        verify(simulatorService, times(3))
+            .generateAuthTokenFromCode(anyString(), anyString(), anyString());
+    }
+
+    @DisplayName("Code is invalid so deny access")
+    @Test
+    public void incorrectCode() throws Exception {
+
+        mockMvc.perform(post("/o/token")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                            .param(CLIENT_ID, CLIENT_ID_HMCTS)
+                            .param(CLIENT_SECRET, "oneClientSecret")
+                            .param(GRANT_TYPE_NAME, GRANT_TYPE)
+                            .param(REDIRECT_URI, "aRedirectUrl")
+                            .param(AUTH_TYPE_CODE, "opjkasdfi9opjasd")
+                            .param(IDAM_SCOPE, "openid profile roles"))
+            .andExpect(status().isUnauthorized())
+            .andReturn();
+
+        verify(simulatorService, never()).generateAToken(anyString(), anyString(), anyString());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorController.java
+++ b/src/main/java/uk/gov/hmcts/reform/rse/idam/simulator/controllers/IdamSimulatorController.java
@@ -149,7 +149,7 @@ public class IdamSimulatorController {
         if (!(grantType.equalsIgnoreCase(GRANT_TYPE_AUTHORIZATION_CODE))) {
             throw new ResponseStatusException(
                 HttpStatus.BAD_REQUEST,
-                "Idam Simulator: Grand type not valid" + grantType + ", must be " + GRANT_TYPE_AUTHORIZATION_CODE
+                "Idam Simulator: Grand type not valid" + grantType + " , must be " + GRANT_TYPE_AUTHORIZATION_CODE
             );
         }
     }
@@ -204,7 +204,7 @@ public class IdamSimulatorController {
         return createUserDetailsList();
     }
 
-    @PostMapping(value = "/o/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    @PostMapping(value = "/o/token", params = "username", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public TokenResponse getOpenIdToken(@RequestParam(CLIENT_ID) final String clientId,
                                         @RequestParam(name = REDIRECT_URI, required = false) final String redirectUri,
                                         @RequestParam(value = "client_secret", required = false)
@@ -213,20 +213,49 @@ public class IdamSimulatorController {
                                         @RequestParam("username") final String username,
                                         @RequestParam(value = "password", required = false)
                                             final String password,
-                                        @RequestParam("scope") final String scope,
-                                        @RequestParam(name = "code", required = false) final String code) {
+                                        @RequestParam("scope") final String scope) {
         LOG.info(
-            "Request OpenId Token for clientId {} Username {} scope {} and code {}",
+            "Request OpenId Token for clientId {} Username {} scope {}",
             clientId,
             username,
-            scope,
-            code
+            scope
         );
         String token = simulatorService.generateACachedToken(username, clientId, grantType);
         String refreshToken = simulatorService.generateAToken(username, clientId, grantType);
         String idToken = simulatorService.generateAToken(username, clientId, grantType);
         LOG.info("Access Open Id Token returned {}", token);
         simulatorService.updateTokenInUser(username, token);
+        return new TokenResponse(token, String.valueOf(expiration), idToken, refreshToken,
+                                 "openid profile roles", "Bearer"
+        );
+    }
+
+    @PostMapping(value = "/o/token", params = "code", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    public TokenResponse getOpenIdTokenFromCode(@RequestParam(CLIENT_ID) final String clientId,
+                                                @RequestParam(name = REDIRECT_URI, required = false)
+                                                final String redirectUri,
+                                                @RequestParam(value = "client_secret", required = false)
+                                                    final String clientSecret,
+                                                @RequestParam("grant_type") final String grantType,
+
+                                                final String password,
+                                                @RequestParam(value = "scope", required = false) final String scope,
+                                                @RequestParam(name = "code") final String code) {
+        LOG.info(
+            "Request OpenId Token for clientId {} scope {} and code {}",
+            clientId,
+            scope,
+            code
+        );
+
+        checkGrantType(grantType);
+        checkCode(code);
+
+        String token = simulatorService.generateAuthTokenFromCode(code, clientId, grantType);
+        String refreshToken = simulatorService.generateAuthTokenFromCode(code, clientId, grantType);
+        String idToken = simulatorService.generateAuthTokenFromCode(code, clientId, grantType);
+        LOG.info("Access Open Id Token generated from code {}", token);
+
         return new TokenResponse(token, String.valueOf(expiration), idToken, refreshToken,
                                  "openid profile roles", "Bearer"
         );

--- a/src/main/java/uk/gov/hmcts/reform/rse/idam/simulator/service/SimulatorService.java
+++ b/src/main/java/uk/gov/hmcts/reform/rse/idam/simulator/service/SimulatorService.java
@@ -38,12 +38,12 @@ public class SimulatorService {
 
     public String generateAuthTokenFromCode(String code, String serviceId, String grantType) {
         Optional<SimObject> userInMemory = liveMemoryService.getByCode(code);
-        String token = generateAToken(userInMemory.get().getEmail(), serviceId, grantType);
-        LOG.info("Oauth2 Token Generated {} for {}", token, userInMemory.get().getEmail());
         if (userInMemory.isEmpty()) {
             LOG.warn("No User for this code " + code);
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Idam Simulator: No User for this code " + code);
         }
+        String token = generateAToken(userInMemory.get().getEmail(), serviceId, grantType);
+        LOG.info("Oauth2 Token Generated {} for {}", token, userInMemory.get().getEmail());
         return token;
     }
 


### PR DESCRIPTION
### Change description ###
The IAC ia-aip-frontend uses ia-idam-express-middleware with openId: true to authenticate.
But the idam simulator doesn't support authentication against /o/token with a code meaning this configuration fails to authenticate.

