### PR TITLE
Use ACR puller identity for PRs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,7 +34,7 @@ jobs:
     - name: "Az CLI login"
       uses: azure/login@v3
       with:
-        client-id: 456b556e-158c-426b-9b5b-ce6ebb32c6a1 # DTS Developers GitHub Actions ACR Publisher 2
+        client-id: ${{ github.event_name == 'pull_request' && '7dbe3da2-315b-4937-bac6-3ab22a9c7b91' || '456b556e-158c-426b-9b5b-ce6ebb32c6a1' }}
         tenant-id: 531ff96d-0ae9-462a-8d2d-bec7c0b42082 # HMCTS.NET
         allow-no-subscriptions: true
 
@@ -61,6 +61,5 @@ jobs:
         docker buildx create --name mybuilder --use
         docker buildx build --push --platform linux/amd64,linux/arm64 -t ${{ env.AZURE_CONTAINER_REGISTRY_URL }}/hmcts/rse/rse-idam-simulator:latest .
       if: github.ref == 'refs/heads/master'
-
 
 


### PR DESCRIPTION
The pull-request federation credential for rse-idam-simulator moved from ACR Publisher 2 to ACR Puller 1. This selects the new pull-only client ID for pull requests while retaining Publisher 2 for master builds, which still push the simulator image.
